### PR TITLE
Fix script compatibility with Processing 3. Size() doesn't accept variables.

### DIFF
--- a/ASDFPixelSort.pde
+++ b/ASDFPixelSort.pde
@@ -22,8 +22,11 @@ int column = 0;
 boolean saved = false;
 
 void setup() {
+  size(400, 200);
+  surface.setResizable(true);
   img = loadImage(imgFileName+"."+fileType);
-  size(img.width, img.height);
+  
+  surface.setSize(img.width, img.height);
   image(img, 0, 0);
 }
 


### PR DESCRIPTION
Fix script compatibility with Processing 3. Size() function accept only integers values, not variables. Using resizable surface now.
Docs: https://processing.org/reference/size_.html
